### PR TITLE
Fix set backup location from backup menu.

### DIFF
--- a/resources/libs/common/config.py
+++ b/resources/libs/common/config.py
@@ -294,7 +294,7 @@ class Config:
 
     def open_settings(self, id=None, cat=None, set=None, activate=False):
         offset = [(100,  200), (-100, -80)]
-        if not id:
+        if id is not None:
             id = self.ADDON_ID
 
         try:


### PR DESCRIPTION
From menu item "Maintenance>Backup/Restore>Backup Location" the open settings function throws an error (Unknown Addon ID "Maintenance".

This commit fixes the function to open the settings page, but still does not go to the correct settings menu item.