### PR TITLE
Fix adding skin to guifix after build backup

### DIFF
--- a/resources/libs/backup.py
+++ b/resources/libs/backup.py
@@ -430,7 +430,7 @@ class Backup:
         _skin = xbmcaddon.Addon(_skin_id)
         _skin_name = xbmcvfs.translatePath(_skin.getAddonInfo('name'))
 
-        with open(temp_txt, 'w') as f:
+        with open(temp_txt, 'w', encoding="utf-8") as f:
             f.write('name="{0}"\n'.format(name))
             f.write('extracted="{0}"\n'.format(extractsize))
             f.write('zipsize="{0}"\n'.format(os.path.getsize(backup_zip)))


### PR DESCRIPTION
prior to this fix i got this error when trying to add skin to guifix after build backup:

AppData\Roaming\Kodi\addons\plugin.program.openwizard\resources\libs\backup.py", line 439, in _backup_info
f.write('programs="{0}"\n'.format(', '.join(programs)) if len(programs) > 0 else 'programs="none"\n')
File "C:\Program Files (x86)\Kodi\system\python\Lib\encodings\cp1252.py", line 19, in encode
return codecs.charmap_encode(input,self.errors,encoding_table)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 259-263: character maps to <undefined>